### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Compilation disassembly viewer for Vim.
 
 To use it:
 
-    git clone https://github.com/sgraham/whodis.git ~/.vim
+    git clone https://github.com/sgraham/whodis.git ~/.vim/whodis
 
 And add:
 


### PR DESCRIPTION
Without this change, this errors out for me like so:
`fatal: destination path '/Users/thakis/.vim' already exists and is not an empty directory.`